### PR TITLE
Button changes

### DIFF
--- a/src/main/java/frc/robot/AutonomousManager.java
+++ b/src/main/java/frc/robot/AutonomousManager.java
@@ -4,6 +4,7 @@ import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandGroupBase;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.commands.ArcadeDriveDistanceCommand;
@@ -33,7 +34,7 @@ public class AutonomousManager {
         // Define variables up here so we can change them easily
         // Motor speed drop will be controlled in IntakeSubsystem
         
-        double motorSpeed = SmartDashboard.getNumber("motorSpeed", 0.3);                                                          // This is in percent
+        double motorSpeed = SmartDashboard.getNumber("motorSpeed", 0.4);                                                          // This is in percent
         double intakeReverseTimeToScore = SmartDashboard.getNumber("intakeReverseTimeToScore", 2);                                // This is in seconds
         double distanceToDriveAfterIntakeMotorSpeedDrop = SmartDashboard.getNumber("distanceToDriveAfterIntakeMotorSpeedDrop", 2);// This is in inches
         double turnAroundAngle = SmartDashboard.getNumber("turnAroundAngle", 171);                                                // This is in degrees
@@ -73,13 +74,15 @@ public class AutonomousManager {
                 // turn on intake 
                 new IntakeStartCommand(this.m_robotMap.getIntake()),
 
-                // Move hopper down and move forward, until our motor speed drops
-                // Parallel command group will run all these commands at the same time
-                new ParallelCommandGroup(
-                    new IntakeArmToggleCommand(this.m_robotMap.getIntake()),
+                // Move hopper down
+                new IntakeArmToggleCommand(this.m_robotMap.getIntake()),
+                // Parallel command group will run all these commands at the same time and stop once one finishes
+                // move forward, until our motor speed drops or 4 seconds passes
+                new ParallelRaceGroup(
 
                     // This command *should* get interrupted, but it will stop after 5 feet for safety
-                    new ArcadeDriveDistanceCommand(this.m_robotMap.getDriveTrain(), 60, motorSpeed)
+                    new ArcadeDriveDistanceCommand(this.m_robotMap.getDriveTrain(), 60, motorSpeed),
+                    new WaitCommand(4)
 
                 ).withInterrupt(() -> {
                     // This withInterrupt() call will stop the parallel command group when

--- a/src/main/java/frc/robot/AutonomousManager.java
+++ b/src/main/java/frc/robot/AutonomousManager.java
@@ -61,10 +61,7 @@ public class AutonomousManager {
                 new ArcadeDriveDistanceCommand(this.m_robotMap.getDriveTrain(), 28, -motorSpeed),
                 
                 // flip a 180, lower the hopper and drive away
-                new ParallelCommandGroup(
-                    new ArcadeDriveTurnCommand(this.m_robotMap, turnAroundAfterScoreAngle, motorSpeed),
-                    new IntakeArmToggleCommand(this.m_robotMap.getIntake())                    
-                ).andThen(() -> System.out.println("finished turn around")),
+                new ArcadeDriveTurnCommand(this.m_robotMap, turnAroundAfterScoreAngle, motorSpeed).andThen(() -> System.out.println("finished turn around")),
                 new ArcadeDriveDistanceCommand(this.m_robotMap.getDriveTrain(), reverseAfterFinished, motorSpeed).andThen(() -> System.out.println("finished back away"))
             );
             this.m_currentCommands = oneBallAuto;
@@ -112,10 +109,7 @@ public class AutonomousManager {
                 new ArcadeDriveDistanceCommand(this.m_robotMap.getDriveTrain(), 28, -motorSpeed),
 
                 // flip a 180, lower the hopper and drive away
-                new ParallelCommandGroup(
-                    new ArcadeDriveTurnCommand(this.m_robotMap, turnAroundAfterScoreAngle, motorSpeed),
-                    new IntakeArmToggleCommand(this.m_robotMap.getIntake())                    
-                ).andThen(() -> System.out.println("finished turn around")),
+                new IntakeArmToggleCommand(this.m_robotMap.getIntake()).andThen(() -> System.out.println("finished turn around")),
                 new ArcadeDriveDistanceCommand(this.m_robotMap.getDriveTrain(), reverseAfterFinished, motorSpeed).andThen(() -> System.out.println("finished back away"))
             );
             this.m_currentCommands = twoBallAuto;
@@ -123,7 +117,7 @@ public class AutonomousManager {
         }
 
         // Start plan along with calibration
-        this.m_currentCommands.schedule();
+        this.m_currentCommands.schedule(false);
     }
 
     public void autonomousPeriodic() {

--- a/src/main/java/frc/robot/AutonomousManager.java
+++ b/src/main/java/frc/robot/AutonomousManager.java
@@ -39,7 +39,7 @@ public class AutonomousManager {
         double distanceToDriveAfterIntakeMotorSpeedDrop = SmartDashboard.getNumber("distanceToDriveAfterIntakeMotorSpeedDrop", 2);// This is in inches
         double turnAroundAngle = SmartDashboard.getNumber("turnAroundAngle", 171);                                                // This is in degrees
         double distanceFromHubToScore = SmartDashboard.getNumber("distanceFromHubToScore", 12);                                   // This is in inches
-        double reverseAfterFinished = SmartDashboard.getNumber("reverseAfterFinished", 141);                                      // This is in inches
+        double reverseAfterFinished = SmartDashboard.getNumber("reverseAfterFinished", 120);                                      // This is in inches
         double turnAroundAfterScoreAngle = SmartDashboard.getNumber("turnAroundAfterScoreAngle", 180);                            // This is in degrees
 
         // This if statement can be change (actually please change it) once we know

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -76,7 +76,9 @@ public class Constants {
     public static final int INTAKE_RIGHT_RETRACT = 3;
 
     // Input
-	public static final int INTAKE_START_BUTTON = 12;
-	public static final int INTAKE_REVERSE_BUTTON = 11;
-	public static final int INTAKE_TOGGLE_BUTTON = 9;
+    // The intake start and reverse are handled directly in input manager
+	//public static final int INTAKE_START_BUTTON = 12;
+	//public static final int INTAKE_REVERSE_BUTTON = 11;
+	public static final int INTAKE_HOLD_BUTTON = 1;
+	public static final int INTAKE_TOGGLE_BUTTON = 2;
 }

--- a/src/main/java/frc/robot/InputManager.java
+++ b/src/main/java/frc/robot/InputManager.java
@@ -76,7 +76,7 @@ public class InputManager {
         assignActionToButtonHold(new ClimbArmRetractCommand(climb), Constants.LONG_ARM_RETRACT_BUTTON, this.m_climbJoystick);
         // assignActionToButtonHold(new ClimbArmPivotCommand(climb), Constants.LONG_ARM_PIVOT_BUTTON, this.m_climbJoystick);
         // assignActionToButtonHold(new ClimbArmPivotReverseCommand(climb), Constants.LONG_ARM_PIVOT_REVERSE_BUTTON, this.m_climbJoystick);
-        assignActionToButtonPress(new ClimbToggleHooksCommand(climb), Constants.HOOKS_TOGGLE_BUTTON, this.m_climbJoystick);
+        assignActionToButtonPress(() -> climb.toggleHooks(), Constants.HOOKS_TOGGLE_BUTTON, this.m_climbJoystick);
         assignActionToButtonPress(() -> { 
             climb.setPivotOverride(true);
             climb.setExtendOverride(true);

--- a/src/main/java/frc/robot/InputManager.java
+++ b/src/main/java/frc/robot/InputManager.java
@@ -1,0 +1,134 @@
+package frc.robot;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import edu.wpi.first.wpilibj.Joystick;
+import frc.robot.commands.*;
+import frc.robot.subsystems.*;
+import frc.robot.subsystems.IntakeSubsystem.IntakeDirection;
+
+public class InputManager {
+    private final Joystick m_joystick1 = new Joystick(Constants.JOYSTICK_1);
+	private final Joystick m_joystick2 = new Joystick(Constants.JOYSTICK_2);
+	private final Joystick m_joystick3 = new Joystick(Constants.JOYSTICK_3);
+
+    private final Joystick m_driveJoystick = this.m_joystick1;
+    private final Joystick m_climbJoystick = this.m_joystick3;
+    private final Joystick m_intakeJoystick = this.m_joystick2;
+
+    private final RobotMap m_robotMap;
+
+    private final IntakeStartCommand m_intakeStartCommand;
+    private final IntakeReverseCommand m_intakeReverseCommand;
+    private final IntakeStopCommand m_intakeStopCommand;
+
+    public InputManager(RobotMap robotMap) {
+        this.m_robotMap = robotMap;
+
+        this.m_intakeStartCommand = new IntakeStartCommand(this.m_robotMap.getIntake());
+        this.m_intakeReverseCommand = new IntakeReverseCommand(this.m_robotMap.getIntake());
+        this.m_intakeStopCommand = new IntakeStopCommand(this.m_robotMap.getIntake());
+
+        configureDefaultCommands();
+        configureButtonBindings();
+    } 
+
+    public void periodic() {
+        switch (this.m_intakeJoystick.getPOV()) {
+            case 315:
+            case 0:
+            case 45:
+                // If pov held forward
+                if (this.m_robotMap.getIntake().getIntakeDirection() != IntakeDirection.Reverse) {
+                    this.m_intakeReverseCommand.schedule();
+                }
+                break;
+            case 135:
+            case 180:
+            case 225:
+                // If pov help backwards
+                if (this.m_robotMap.getIntake().getIntakeDirection() != IntakeDirection.Forward) {
+                    this.m_intakeStartCommand.schedule();
+                }
+                break;
+            default:
+                // If pov held literally anywhere else
+                if (this.m_robotMap.getIntake().getIntakeDirection() != IntakeDirection.Stop) {
+                    this.m_intakeStopCommand.schedule();
+                }
+                break;
+        }
+    }
+    
+    private void configureDefaultCommands() {
+        ArcadeDriveJoystickCommand command = new ArcadeDriveJoystickCommand(this.m_robotMap.getDriveTrain(), this.m_driveJoystick);
+        /* Test of command based robot control */
+        this.m_robotMap.getDriveTrain().setDefaultCommand(command);
+    }
+
+    private void configureButtonBindings() {
+        // Notice the difference between assignActionToButtonPress and assignActionToButtonHold
+
+        // Climb
+        ClimbSubsystem climb = this.m_robotMap.getClimb();
+
+        assignActionToButtonHold(new ClimbArmExtendCommand(climb), Constants.LONG_ARM_EXTEND_BUTTON, this.m_climbJoystick);
+        assignActionToButtonHold(new ClimbArmRetractCommand(climb), Constants.LONG_ARM_RETRACT_BUTTON, this.m_climbJoystick);
+        // assignActionToButtonHold(new ClimbArmPivotCommand(climb), Constants.LONG_ARM_PIVOT_BUTTON, this.m_climbJoystick);
+        // assignActionToButtonHold(new ClimbArmPivotReverseCommand(climb), Constants.LONG_ARM_PIVOT_REVERSE_BUTTON, this.m_climbJoystick);
+        assignActionToButtonPress(new ClimbToggleHooksCommand(climb), Constants.HOOKS_TOGGLE_BUTTON, this.m_climbJoystick);
+        assignActionToButtonPress(() -> { 
+            climb.setPivotOverride(true);
+            climb.setExtendOverride(true);
+        }, Constants.LONG_ARM_OVERRIDE_BUTTON, this.m_climbJoystick);
+        assignActionToButtonRelease(() -> { 
+            climb.setPivotOverride(false);
+            climb.setExtendOverride(false);
+        }, Constants.LONG_ARM_OVERRIDE_BUTTON, this.m_climbJoystick);
+
+        // Intake
+        IntakeSubsystem intake = this.m_robotMap.getIntake();
+
+        // // Add start to press and stop to raise
+        // assignActionToButtonPress(new IntakeStartCommand(intake), Constants.INTAKE_START_BUTTON, this.m_intakeJoystick);
+        // assignActionToButtonRelease(new IntakeStopCommand(intake), Constants.INTAKE_START_BUTTON, this.m_intakeJoystick);
+
+        // // Do the same for reverse command
+        // assignActionToButtonPress(new IntakeReverseCommand(intake), Constants.INTAKE_REVERSE_BUTTON, this.m_intakeJoystick);
+        // assignActionToButtonRelease(new IntakeStopCommand(intake), Constants.INTAKE_REVERSE_BUTTON, this.m_intakeJoystick);
+        
+        assignActionToButtonPress(new IntakeArmToggleCommand(intake), Constants.INTAKE_HOLD_BUTTON, this.m_intakeJoystick);
+        assignActionToButtonRelease(new IntakeArmToggleCommand(intake), Constants.INTAKE_HOLD_BUTTON, this.m_intakeJoystick);
+        assignActionToButtonPress(new IntakeArmToggleCommand(intake), Constants.INTAKE_TOGGLE_BUTTON, this.m_intakeJoystick);
+    }
+
+    private JoystickButton assignActionToButtonPress(Command command, int buttonId, Joystick joystick) {
+        JoystickButton button = new JoystickButton(joystick, buttonId);
+        button.whenPressed(command);
+        return button;
+    }
+
+    private JoystickButton assignActionToButtonPress(Runnable action, int buttonId, Joystick joystick) {
+        JoystickButton button = new JoystickButton(joystick, buttonId);
+        button.whenPressed(action);
+        return button;
+    }
+
+    private JoystickButton assignActionToButtonRelease(Command command, int buttonID, Joystick joystick) {
+        JoystickButton button = new JoystickButton(joystick, buttonID);
+        button.whenReleased(command);
+        return button;
+    }
+
+    private JoystickButton assignActionToButtonRelease(Runnable action, int buttonID, Joystick joystick) {
+        JoystickButton button = new JoystickButton(joystick, buttonID);
+        button.whenReleased(action);
+        return button;
+    }
+
+    private JoystickButton assignActionToButtonHold(Command command, int buttonId, Joystick joystick) {
+        JoystickButton button = new JoystickButton(joystick, buttonId);
+        button.whenHeld(command);
+        return button;
+    }
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -55,7 +55,7 @@ public class Robot extends TimedRobot {
         SmartDashboard.putNumber("distanceToDriveAfterIntakeMotorSpeedDrop", 2);// This is in inches
         SmartDashboard.putNumber("turnAroundAngle", 171);                       // This is in degrees
         SmartDashboard.putNumber("distanceFromHubToScore", 30);                 // This is in inches
-        SmartDashboard.putNumber("reverseAfterFinished", 141);                  // This is in inches
+        SmartDashboard.putNumber("reverseAfterFinished", 120);                  // This is in inches
         SmartDashboard.putNumber("turnAroundAfterScoreAngle", 180);             // This is in degrees
     }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -50,7 +50,7 @@ public class Robot extends TimedRobot {
         this.m_autonomousManager = new AutonomousManager(this.m_robotMap);
 
         // Temp vars for auto
-        SmartDashboard.putNumber("motorSpeed", 0.3);                            // This is in percent
+        SmartDashboard.putNumber("motorSpeed", 0.4);                            // This is in percent
         SmartDashboard.putNumber("intakeReverseTimeToScore", 2);                // This is in seconds
         SmartDashboard.putNumber("distanceToDriveAfterIntakeMotorSpeedDrop", 2);// This is in inches
         SmartDashboard.putNumber("turnAroundAngle", 171);                       // This is in degrees

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -19,6 +19,8 @@ import frc.robot.commands.ClimbCalibrationCommand;
 public class Robot extends TimedRobot {
     private RobotMap m_robotMap;
 
+    private InputManager m_inputManager;
+
     private AutonomousManager m_autonomousManager;
 
     /**
@@ -43,6 +45,8 @@ public class Robot extends TimedRobot {
 
         this.m_robotMap = new RobotMap(); 
 
+        this.m_inputManager = new InputManager(this.m_robotMap);
+
         this.m_autonomousManager = new AutonomousManager(this.m_robotMap);
 
         // Temp vars for auto
@@ -65,6 +69,7 @@ public class Robot extends TimedRobot {
     @Override
     public void robotPeriodic() {
         CommandScheduler.getInstance().run();
+        this.m_inputManager.periodic();
     }
 
     /**

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -2,19 +2,11 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
-import edu.wpi.first.wpilibj.Joystick;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
-import frc.robot.commands.*;
 import frc.robot.subsystems.*;
 
 /* Creates robot subsystems and commands, binds those commands to triggering 
     events (such as buttons), and specify which commands will run in autonomous. */
 public class RobotMap {
-    private final Joystick m_joystick1 = new Joystick(Constants.JOYSTICK_1);
-	private final Joystick m_joystick2 = new Joystick(Constants.JOYSTICK_2);
-	private final Joystick m_joystick3 = new Joystick(Constants.JOYSTICK_3);
-
     // yes the class name is weird, the docs say it's a misnomer
     // Also put this at least a ft away from the front bumper, also leave it 1-2ft above the ground
     private final AnalogPotentiometer m_ultrasonicSensor = new AnalogPotentiometer(0, Constants.INCHES_PER_5V);
@@ -28,78 +20,8 @@ public class RobotMap {
     private final IntakeSubsystem m_intake = new IntakeSubsystem();
 
     public RobotMap() {
-		this.configureDefaultCommands();
-		this.configureButtonBindings();
+		
 	}
-
-    private void configureButtonBindings() {
-        // Notice the difference between assignActionToButtonPress and assignActionToButtonHold
-
-        // Climb
-        Joystick climbJoystick = this.m_joystick3; // The joystick variables will make it easier to swap joysticks
-        assignActionToButtonHold(new ClimbArmExtendCommand(this.m_climb), Constants.LONG_ARM_EXTEND_BUTTON, climbJoystick);
-        assignActionToButtonHold(new ClimbArmRetractCommand(this.m_climb), Constants.LONG_ARM_RETRACT_BUTTON, climbJoystick);
-        assignActionToButtonHold(new ClimbArmPivotCommand(this.m_climb), Constants.LONG_ARM_PIVOT_BUTTON, climbJoystick);
-        assignActionToButtonHold(new ClimbArmPivotReverseCommand(this.m_climb), Constants.LONG_ARM_PIVOT_REVERSE_BUTTON, climbJoystick);
-        assignActionToButtonPress(new ClimbToggleHooksCommand(this.m_climb), Constants.HOOKS_TOGGLE_BUTTON, climbJoystick);
-        assignActionToButtonPress(() -> { 
-            this.m_climb.setPivotOverride(true);
-            this.m_climb.setExtendOverride(true);
-        }, Constants.LONG_ARM_OVERRIDE_BUTTON, climbJoystick);
-        assignActionToButtonRelease(() -> { 
-            this.m_climb.setPivotOverride(false);
-            this.m_climb.setExtendOverride(false);
-        }, Constants.LONG_ARM_OVERRIDE_BUTTON, climbJoystick);
-
-        // Intake
-        Joystick intakeJoystick = this.m_joystick3;
-
-        // Add start to press and stop to raise
-        assignActionToButtonPress(new IntakeStartCommand(this.m_intake), Constants.INTAKE_START_BUTTON, intakeJoystick);
-        assignActionToButtonRelease(new IntakeStopCommand(this.m_intake), Constants.INTAKE_START_BUTTON, intakeJoystick);
-
-        // Do the same for reverse command
-        assignActionToButtonPress(new IntakeReverseCommand(this.m_intake), Constants.INTAKE_REVERSE_BUTTON, intakeJoystick);
-        assignActionToButtonRelease(new IntakeStopCommand(this.m_intake), Constants.INTAKE_REVERSE_BUTTON, intakeJoystick);
-        
-        assignActionToButtonPress(new IntakeArmToggleCommand(this.m_intake), Constants.INTAKE_TOGGLE_BUTTON, intakeJoystick);
-    }
-
-    private JoystickButton assignActionToButtonPress(Command command, int buttonId, Joystick joystick) {
-        JoystickButton button = new JoystickButton(joystick, buttonId);
-        button.whenPressed(command);
-        return button;
-    }
-
-    private JoystickButton assignActionToButtonPress(Runnable action, int buttonId, Joystick joystick) {
-        JoystickButton button = new JoystickButton(joystick, buttonId);
-        button.whenPressed(action);
-        return button;
-    }
-
-    private JoystickButton assignActionToButtonRelease(Command command, int buttonID, Joystick joystick) {
-        JoystickButton button = new JoystickButton(joystick, buttonID);
-        button.whenReleased(command);
-        return button;
-    }
-
-    private JoystickButton assignActionToButtonRelease(Runnable action, int buttonID, Joystick joystick) {
-        JoystickButton button = new JoystickButton(joystick, buttonID);
-        button.whenReleased(action);
-        return button;
-    }
-
-    private JoystickButton assignActionToButtonHold(Command command, int buttonId, Joystick joystick) {
-        JoystickButton button = new JoystickButton(joystick, buttonId);
-        button.whenHeld(command);
-        return button;
-    }
-
-    private void configureDefaultCommands() {
-        ArcadeDriveJoystickCommand command = new ArcadeDriveJoystickCommand(this.m_driveTrain, this.m_joystick1);
-        /* Test of command based robot control */
-        this.m_driveTrain.setDefaultCommand(command);
-    }
 
     public void onDisable() {
         this.m_gyro.calibrate();

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -25,6 +25,7 @@ public class RobotMap {
 
     public void onDisable() {
         this.m_gyro.calibrate();
+        this.m_intake.stopIntake();
 	}
 
     public DriveTrainSubsystem getDriveTrain() {

--- a/src/main/java/frc/robot/Subsystems/ClimbSubsystem.java
+++ b/src/main/java/frc/robot/Subsystems/ClimbSubsystem.java
@@ -9,7 +9,7 @@ import frc.robot.Constants;
 
 public class ClimbSubsystem extends SubsystemBase {
     private final WPI_TalonSRX m_longArmExtendMotor = new WPI_TalonSRX(Constants.LONG_ARM_EXTEND_MOTOR);
-    private final float m_longArmExtendMotorSpeed = 0.5f;
+    private final float m_longArmExtendMotorSpeed = 0.7f;
     private final float m_longArmRetractMotorSpeed = 0.7f;
     private final DigitalInput m_longArmExtendLimitSwitch = new DigitalInput(1);
     private boolean m_extendOverride = false;

--- a/src/main/java/frc/robot/Subsystems/ClimbSubsystem.java
+++ b/src/main/java/frc/robot/Subsystems/ClimbSubsystem.java
@@ -9,8 +9,8 @@ import frc.robot.Constants;
 
 public class ClimbSubsystem extends SubsystemBase {
     private final WPI_TalonSRX m_longArmExtendMotor = new WPI_TalonSRX(Constants.LONG_ARM_EXTEND_MOTOR);
-    private final float m_longArmExtendMotorSpeed = 0.7f;
-    private final float m_longArmRetractMotorSpeed = 0.7f;
+    private final float m_longArmExtendMotorSpeed = 0.55f;
+    private final float m_longArmRetractMotorSpeed = 1f;
     private final DigitalInput m_longArmExtendLimitSwitch = new DigitalInput(1);
     private boolean m_extendOverride = false;
     
@@ -21,7 +21,7 @@ public class ClimbSubsystem extends SubsystemBase {
 
     private final WPI_TalonSRX m_smallArmMotor1 = new WPI_TalonSRX(Constants.SMALL_ARM_1_MOTOR);
     private final WPI_TalonSRX m_smallArmMotor2 = new WPI_TalonSRX(Constants.SMALL_ARM_2_MOTOR);
-    private final float m_smallArmMotorSpeedLeft = 0.5f;
+    private final float m_smallArmMotorSpeedLeft = 0.9f;
     private final float m_smallArmMotorSpeedRight = 0.9f;
     private final int m_timeToToggleHooks = 500; // Time in MS it takes to toggle the hooks
     private long m_timeStartedTogglingHooks;
@@ -135,7 +135,7 @@ public class ClimbSubsystem extends SubsystemBase {
     }
 
     public double getArmExtendDistance() {
-        // Divide by 1024 because CTRE uses 0-4096 as a full rotation
+        // Divide by 4096 because CTRE uses 0-4096 as a full rotation
         return Math.abs(this.m_longArmExtendMotor.getSelectedSensorPosition() * Constants.ARM_EXTEND_POSITION_FACTOR / 4096);
     }
 

--- a/src/main/java/frc/robot/Subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/Subsystems/IntakeSubsystem.java
@@ -11,6 +11,7 @@ import frc.robot.Constants;
 public class IntakeSubsystem extends SubsystemBase {
     private final WPI_TalonSRX m_intakeMotor = new WPI_TalonSRX(Constants.INTAKE_MOTOR);
     private final float m_motorSpeed = 0.9f;
+    private IntakeDirection m_intakeDirection;
 
     private final float m_amperagePercentThreshold = 1.7f;
     private boolean m_hasIntakedBall = false;
@@ -66,18 +67,25 @@ public class IntakeSubsystem extends SubsystemBase {
     }
 
     public void startIntake() {
+        this.m_intakeDirection = IntakeDirection.Forward;
         this.m_intakeMotor.set(ControlMode.PercentOutput, m_motorSpeed);
         this.m_timeStartIntake = System.currentTimeMillis();
     }
 
     public void reverseIntake() {
+        this.m_intakeDirection = IntakeDirection.Reverse;
         this.m_intakeMotor.set(ControlMode.PercentOutput, -m_motorSpeed);
         this.m_timeStartIntake = System.currentTimeMillis();
     }
 
     public void stopIntake() {
+        this.m_intakeDirection = IntakeDirection.Stop;
         this.m_intakeMotor.set(ControlMode.PercentOutput, 0.0);
         this.m_timeStartIntake = Long.MAX_VALUE;
+    }
+
+    public IntakeDirection getIntakeDirection() {
+        return this.m_intakeDirection;
     }
     
     public void toggleArm() {
@@ -95,5 +103,11 @@ public class IntakeSubsystem extends SubsystemBase {
 
     public boolean hasIntakedBall() {
         return this.m_hasIntakedBall;
+    }
+
+    public enum IntakeDirection {
+        Reverse,
+        Stop,
+        Forward
     }
 }

--- a/src/main/java/frc/robot/Subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/Subsystems/IntakeSubsystem.java
@@ -10,7 +10,7 @@ import frc.robot.Constants;
 
 public class IntakeSubsystem extends SubsystemBase {
     private final WPI_TalonSRX m_intakeMotor = new WPI_TalonSRX(Constants.INTAKE_MOTOR);
-    private final float m_motorSpeed = 0.9f;
+    private final float m_motorSpeed = 0.75f;
     private IntakeDirection m_intakeDirection;
 
     private final float m_amperagePercentThreshold = 1.7f;


### PR DESCRIPTION
Changes:
- Increase auto motor speed from 0.3 to 0.4
- Decrease distance reversed after auto from 141 inches to 120
- Not have the bot backup before turning after scoring in auto
- Add a 4 second timeout when the bot is picking up a ball in 2 ball auto
- Make the auto command uninterruptable 
- Add input manager and rebind a lot of buttons
  - Change the intake toggle button to 2
  - Add a hold button for toggle on button 1
  - Add intake start and reverse to the POV (hat) on the joystick
  - Add button 8 as an override for software protections in climb